### PR TITLE
Add semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: java
+sudo: required
+jdk:
+  - oraclejdk8
+cache:
+  directories:
+    - "$HOME/.CommandBox/artifacts/"
+before_install:
+  - sudo apt-key adv --keyserver keys.gnupg.net --recv 6DA70622
+  - sudo echo "deb http://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a /etc/apt/sources.list.d/commandbox.list
+install:
+  - sudo apt-get update && sudo apt-get --assume-yes install commandbox
+  - box install
+script:
+  - echo "No tests!"
+after_success:
+  - box install commandbox-semantic-release
+  - box config set endpoints.forgebox.APIToken=${FORGEBOX_TOKEN}
+  - box semantic-release
+notifications:
+  email: false

--- a/box.json
+++ b/box.json
@@ -41,9 +41,7 @@
     "devDependencies":{},
     "installPaths":{},
     "scripts":{
-        "postVersion":"package set location='bdw429s/commandbox-fusionreactor#v`package version`'",
-        "onRelease":"publish",
-        "postPublish":"!git push --follow-tags"
+        "postVersion":"package set location='bdw429s/commandbox-fusionreactor#v`package version`'"
     },
     "ignore":[
         "test",


### PR DESCRIPTION
There are some steps you need on the Travis side.  You need a few tokens set up as environment variables:
1. `FORGEBOX_TOKEN`, an API token for ForgeBox for the user that owns the package (`bdw429s`)
2. `GH_TOKEN`, a GitHub token for the user that owns the package.  The token needs at least the `repo` scope.  I've been creating a personal access token for each package I add semantic-release to.
3. `TRAVIS_TOKEN`, a Travis CI token for the user that owns the package.  You can get that on this page when you are logged in to Travis: https://travis-ci.org/profile

Here's what it looks like to add these in the Travis UI.
![qb - travis ci 2018-07-16 09-04-17](https://user-images.githubusercontent.com/2583646/42766288-43acacbe-88d7-11e8-83d5-6dff09f89b12.png)

This will only release on the `master` branch.  It will also start appending to a `CHANGELOG.md` as well as creating a GitHub release. 