### PR TITLE
Feature/hide license key

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -169,7 +169,7 @@ component {
 			serverInfo.JVMArgs &= ' "-javaagent:#replaceNoCase( serverInfo.FRHomeDirectory, '\', '\\', 'all' )#fusionreactor.jar=name=#serverInfo.name#,address=#address#,external=#serverInfo.FRexternalServerEnable#"';
 
 			if( len( serverInfo.FRlicenseKey ) ) { serverInfo.JVMArgs &= ' -Dfrlicense=#serverInfo.FRlicenseKey#'; }
-			if( len( serverInfo.FRlicenseKeyHidden ) ) { serverInfo.JVMArgs &= ' -Dfr.license.key.hidden=#serverInfo.FRlicenseKeyHidden#'; }
+			if( isBoolean( serverInfo.FRlicenseKeyHidden ) && serverInfo.FRlicenseKeyHidden ) { serverInfo.JVMArgs &= ' -Dfr.license.key.hidden=#serverInfo.FRlicenseKeyHidden#'; }
 			if( len( thisPassword ) ) { serverInfo.JVMArgs &= ' -Dfradminpassword=#thisPassword#'; }
 			if( len( serverInfo.FRRESTRegisterURL ) ) { serverInfo.JVMArgs &= ' -Dfrregisterwith=#serverInfo.FRRESTRegisterURL#'; }
 			if( len( serverInfo.FRRESTShutdownAction ) ) { serverInfo.JVMArgs &= ' -Dfrshutdownaction=#serverInfo.FRRESTShutdownAction#'; }

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -6,6 +6,7 @@ component {
 			'installID' = 'fusionreactor@^8.0.0',
 			'debugEnable' = true,
 			'licenseKey' = '',
+			'hideLicenseKey' = false,
 			'reactorConfFile' = '',
 			'FRPort' = '',
 			'FRHost' = '',
@@ -58,6 +59,7 @@ component {
 			serverInfo.FRPort = serverJSON.fusionreactor.port ?: defaults.fusionreactor.port ?: serverInfo.FRPort ?: settings.FRPort;
 			serverInfo.FRHost = serverJSON.web.host ?: defaults.web.host ?: serverInfo.host ?: settings.host;
 			serverInfo.FRLicenseKey = serverJSON.fusionreactor.licenseKey ?: defaults.fusionreactor.licenseKey ?: settings.licenseKey;
+			serverInfo.FRLicenseKeyHidden = serverJSON.fusionreactor.hideLicenseKey ?: defaults.fusionreactor.hideLicenseKey ?: settings.hideLicenseKey;
 			serverInfo.FRInstallID = serverJSON.fusionreactor.installID ?: defaults.fusionreactor.installID ?: settings.installID;
 			serverInfo.FRDebugEnable = serverJSON.fusionreactor.debugEnable ?: defaults.fusionreactor.debugEnable ?: settings.debugEnable;
 			serverInfo.FRRESTRegisterURL = serverJSON.fusionreactor.RESTRegisterURL ?: defaults.fusionreactor.RESTRegisterURL ?: settings.RESTRegisterURL;
@@ -167,6 +169,7 @@ component {
 			serverInfo.JVMArgs &= ' "-javaagent:#replaceNoCase( serverInfo.FRHomeDirectory, '\', '\\', 'all' )#fusionreactor.jar=name=#serverInfo.name#,address=#address#,external=#serverInfo.FRexternalServerEnable#"';
 
 			if( len( serverInfo.FRlicenseKey ) ) { serverInfo.JVMArgs &= ' -Dfrlicense=#serverInfo.FRlicenseKey#'; }
+			if( len( serverInfo.FRlicenseKeyHidden ) ) { serverInfo.JVMArgs &= ' -Dfr.license.key.hidden=#serverInfo.FRlicenseKeyHidden#'; }
 			if( len( thisPassword ) ) { serverInfo.JVMArgs &= ' -Dfradminpassword=#thisPassword#'; }
 			if( len( serverInfo.FRRESTRegisterURL ) ) { serverInfo.JVMArgs &= ' -Dfrregisterwith=#serverInfo.FRRESTRegisterURL#'; }
 			if( len( serverInfo.FRRESTShutdownAction ) ) { serverInfo.JVMArgs &= ' -Dfrshutdownaction=#serverInfo.FRRESTShutdownAction#'; }


### PR DESCRIPTION
Updated per your instructions in Slack. Had to clear our the `commandbox-fusionreactor.zip` file found in `~/.CommandBox/artifacts` before it would load the version install via git for my branch.

When starting the server with debugging output to the console, the default output contains all the JVM args that are starting the server. The license key is shown in plain text as part of that output. I assume that's in the core CommandBox setup. I might address that later if possible. 